### PR TITLE
Add solution

### DIFF
--- a/php-api-pro/problem-detail.php
+++ b/php-api-pro/problem-detail.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once 'vendor/autoload.php';
+require_once '../vendor/autoload.php';
 
 /**
  * Challenge:
@@ -19,7 +19,7 @@ enum ProblemDetail: int
     case BAD_REQUEST = 400;
     case UNAUTHORIZED = 401;
     case FORBIDDEN = 403;
-    // ...
+    case NOT_FOUND = 404;
 
     public function type(): string
     {
@@ -32,4 +32,6 @@ enum ProblemDetail: int
     }
 }
 
-$statusCode = 403;
+$statusCode = 404;
+
+var_dump(ProblemDetail::tryFrom($statusCode)->type());

--- a/php-api-pro/problem-detail.php
+++ b/php-api-pro/problem-detail.php
@@ -34,4 +34,4 @@ enum ProblemDetail: int
 
 $statusCode = 404;
 
-var_dump(ProblemDetail::tryFrom($statusCode)->type());
+var_dump(ProblemDetail::tryFrom($statusCode)?->type());


### PR DESCRIPTION
This PR adds a solution to the problem.

I used `tryFrom` here because it will return null if the provided `value` does not match any declared case in the `ProblemDetail` Enum instead of throwing an exception.

Output:

```sh
➜  php-api-pro · main ✗ php problem-detail.php
/Users/legion/Workspace/garyclarketech-code-challenge/php-api-pro/problem-detail.php:37:
string(59) "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3"

➜  php-api-pro · main ✗ php problem-detail.php
/Users/legion/Workspace/garyclarketech-code-challenge/php-api-pro/problem-detail.php:37:
string(59) "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1"

➜  php-api-pro · main ✗ php problem-detail.php
/Users/legion/Workspace/garyclarketech-code-challenge/php-api-pro/problem-detail.php:37:
string(57) "https://datatracker.ietf.org/doc/html/rfc7235#section-3.1"

➜  php-api-pro · main ✗ php problem-detail.php
/Users/legion/Workspace/garyclarketech-code-challenge/php-api-pro/problem-detail.php:37:
string(11) "about:blank"
```

EDIT:

The commit contains `404` status code because it was the last case I tested.

EDIT 2:

Now, if we try to pass a status code or an enum case that doesn't exist, it will return null instead of throwing an exception.

Output:

```
➜  php-api-pro · main ✗ php problem-detail.php
/Users/legion/Workspace/garyclarketech-code-challenge/php-api-pro/problem-detail.php:37:
NULL
```