### PR TITLE
Autoload classes using PSR-4

### DIFF
--- a/php-framework-pro/psr4-autoloading.json
+++ b/php-framework-pro/psr4-autoloading.json
@@ -12,5 +12,9 @@
     "require": {
         "symfony/var-dumper": "6.3.x-dev"
     },
-    "challenge_instructions": "How should this file be edited so that the 'App' namespace is mapped to the 'src' directory using PSR-4 autoloading? What command should be run after this is added?"
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
 }


### PR DESCRIPTION
1. How should this file be edited so that the 'App' namespace is mapped to the 'src' directory using PSR-4 autoloading?
To map the 'App' namespace to the 'src' directory using PSR-4 autoloading, add the following configuration to your composer.json file:

```
"autoload": {
    "psr-4": {
        "App\\": "src/"
    }
}
```
2. What command should be run after this is added?
After adding this configuration, run the following command to regenerate the Composer autoloader files:

`composer dump-autoload`